### PR TITLE
Fix business type not FNB/RETAIL in BusynessManager bug

### DIFF
--- a/src/main/java/busynessmanager/BusynessManager.java
+++ b/src/main/java/busynessmanager/BusynessManager.java
@@ -9,6 +9,10 @@ import busynessmanager.revenue.RevenueCalculator;
 import busynessmanager.managers.SalesManager;
 import busynessmanager.managers.SearchManager;
 import busynessmanager.UI_Constants.UI;
+
+import static busynessmanager.UI_Constants.Constants.BM_UPPERCASE_REGEX;
+import static busynessmanager.UI_Constants.Constants.BM_BUSINESSTYPE_FNB;
+import static busynessmanager.UI_Constants.Constants.BM_BUSINESSTYPE_RETAIL;
 import static busynessmanager.UI_Constants.Constants.BM_WELCOME_MESSAGE;
 import static busynessmanager.UI_Constants.Constants.BM_NO_INPUT_ERROR_MESSAGE;
 import static busynessmanager.UI_Constants.Constants.BM_ENTER_BUSINESS_ID_MESSAGE;
@@ -19,6 +23,7 @@ import static busynessmanager.UI_Constants.Constants.BM_INVALID_CREDENTIALS_MESS
 import static busynessmanager.UI_Constants.Constants.BM_FIRST_SETUP_MESSAGE;
 import static busynessmanager.UI_Constants.Constants.BM_ENTER_NAME_MESSAGE;
 import static busynessmanager.UI_Constants.Constants.BM_ENTER_BUSINESS_TYPE_MESSAGE;
+import static busynessmanager.UI_Constants.Constants.BM_INVALID_BUSINESSTYPE_ERROR_MESSAGE;
 import static busynessmanager.UI_Constants.Constants.BM_SETUP_COMPLETE_MESSAGE;
 import static busynessmanager.UI_Constants.Constants.BM_READY_MESSAGE;
 import static busynessmanager.UI_Constants.Constants.BM_WAITING_INPUT_MESSAGE;
@@ -28,10 +33,14 @@ import static busynessmanager.UI_Constants.Constants.BM_EXIT_MESSAGE;
 public class BusynessManager {
     private static final HashMap<String, String> credentials = new HashMap<>(); // Stores business ID & passwords
 
+    private enum BusinessType {
+        FNB, RETAIL
+    }
+
     private String businessID;
     private String businessName;
     private String businessPassword;
-    private String businessType; // Enum: FNB / RETAIL
+    private BusinessType businessType;
 
     private final CommandParser commandParser;
 
@@ -42,6 +51,7 @@ public class BusynessManager {
         SearchManager searchManager = new SearchManager(inventoryManager);
         commandParser = new CommandParser(inventoryManager, salesManager, revenueCalculator, searchManager);
     }
+
 
     public static void main(String[] args) {
         BusynessManager manager = new BusynessManager();
@@ -119,7 +129,22 @@ public class BusynessManager {
             UI.printErrorMessage(BM_NO_INPUT_ERROR_MESSAGE);
             return;
         }
-        businessType = scanner.nextLine().trim().toUpperCase();
+
+        BusinessType businessType = null;
+
+        while (businessType == null) {
+            String businessTypeString = scanner.nextLine().trim();
+
+            if (businessTypeString.matches(BM_UPPERCASE_REGEX)
+                    && businessTypeString.equals(BM_BUSINESSTYPE_FNB)) {
+                businessType = BusinessType.FNB;
+            } else if (businessTypeString.matches(BM_UPPERCASE_REGEX)
+                    && businessTypeString.equals(BM_BUSINESSTYPE_RETAIL)) {
+                businessType = BusinessType.RETAIL;
+            } else {
+                UI.printMessage(BM_INVALID_BUSINESSTYPE_ERROR_MESSAGE);
+            }
+        }
 
         businessID = id;
         credentials.put(businessID, businessPassword);

--- a/src/main/java/busynessmanager/UI_Constants/Constants.java
+++ b/src/main/java/busynessmanager/UI_Constants/Constants.java
@@ -22,11 +22,13 @@ public class Constants {
     public static final int INDEX_5 = 5;
     public static final int INDEX_6 = 6;
     public static final int INDEX_7 = 7;
-    public static final int INDEX_8 = 8;
-    public static final int INDEX_9 = 9;
     public static final String INVALID_NAME = "INVALID_NAME";
 
     // BusynessManager
+    public static final String BM_UPPERCASE_REGEX = "[A-Z]+";
+    public static final String BM_BUSINESSTYPE_FNB = "FNB";
+    public static final String BM_BUSINESSTYPE_RETAIL = "RETAIL";
+
     public static final String BM_WELCOME_MESSAGE = "Welcome to Busyness Manager!";
     public static final String BM_NO_INPUT_ERROR_MESSAGE = "Error: No input detected. Exiting...";
     public static final String BM_ENTER_BUSINESS_ID_MESSAGE = "Enter Business ID: ";
@@ -37,6 +39,7 @@ public class Constants {
     public static final String BM_FIRST_SETUP_MESSAGE = "First-time setup required.";
     public static final String BM_ENTER_NAME_MESSAGE = "Enter Business Name: ";
     public static final String BM_ENTER_BUSINESS_TYPE_MESSAGE = "Enter Business Type (FNB/RETAIL): ";
+    public static final String BM_INVALID_BUSINESSTYPE_ERROR_MESSAGE = "Invalid business type. Please try again.";
     public static final String BM_SETUP_COMPLETE_MESSAGE = "Business setup complete!";
     public static final String BM_READY_MESSAGE = "Busyness Manager is ready. Type 'help' for commands.";
     public static final String BM_WAITING_INPUT_MESSAGE = ">";
@@ -44,6 +47,7 @@ public class Constants {
     public static final String BM_EXIT_MESSAGE = "Exiting Busyness Manager...";
 
     // CommandParser
+    public static final String CP_NAME = "CommandParser";
     public static final int CP_COMMAND_SEPARATOR_INDEX = -1;
     public static final String CP_ID_REGEX = "ID_\\d{4}";
     public static final String CP_SPLIT_REGEX = "\\s+";
@@ -73,6 +77,10 @@ public class Constants {
     public static final String CP_INVALID_NUMERAL_MESSAGE_2 = "Quantity is not a number. Please try again.";
     public static final String CP_INVALID_ID_FORMAT_MESSAGE = "Invalid format. /id.";
     public static final String CP_INVALID_ID_MESSAGE = "ID is invalid. Please try again.";
+
+    public static final String CP_NEGATIVE_QUANTITY_MESSAGE = "Quantity is a negative number.";
+    public static final String CP_NEGATIVE_PRICE_MESSAGE = "Price is not a positive number.";
+    public static final String CP_EXCEPTION_LOG_MESSAGE = "Exception thrown.";
 
     // Product
     public static final String ID_FORMAT = "ID_%04d";

--- a/src/main/java/busynessmanager/parser/CommandParser.java
+++ b/src/main/java/busynessmanager/parser/CommandParser.java
@@ -16,6 +16,7 @@ import static busynessmanager.UI_Constants.Constants.INDEX_4;
 import static busynessmanager.UI_Constants.Constants.INDEX_5;
 import static busynessmanager.UI_Constants.Constants.INDEX_6;
 import static busynessmanager.UI_Constants.Constants.INDEX_7;
+import static busynessmanager.UI_Constants.Constants.CP_NAME;
 import static busynessmanager.UI_Constants.Constants.CP_COMMAND_SEPARATOR_INDEX;
 import static busynessmanager.UI_Constants.Constants.CP_ADD_COMMAND;
 import static busynessmanager.UI_Constants.Constants.CP_DELETE_COMMAND;
@@ -42,6 +43,9 @@ import static busynessmanager.UI_Constants.Constants.CP_INVALID_ID_MESSAGE;
 import static busynessmanager.UI_Constants.Constants.CP_INVALID_ID_FORMAT_MESSAGE;
 import static busynessmanager.UI_Constants.Constants.CP_INVALID_NUMERAL_MESSAGE;
 import static busynessmanager.UI_Constants.Constants.CP_INVALID_NUMERAL_MESSAGE_2;
+import static busynessmanager.UI_Constants.Constants.CP_NEGATIVE_QUANTITY_MESSAGE;
+import static busynessmanager.UI_Constants.Constants.CP_NEGATIVE_PRICE_MESSAGE;
+import static busynessmanager.UI_Constants.Constants.CP_EXCEPTION_LOG_MESSAGE;
 
 import busynessmanager.exceptions.InvalidStringException;
 import busynessmanager.exceptions.InvalidCommandException;
@@ -56,7 +60,7 @@ import java.util.logging.Logger;
 public class CommandParser {
 
 
-    private static final Logger logger = Logger.getLogger("CommandParser");
+    private static final Logger logger = Logger.getLogger(CP_NAME);
     private final InventoryManager inventoryManager;
     private final SalesManager salesManager;
     private final RevenueCalculator revenueCalculator;
@@ -113,7 +117,7 @@ public class CommandParser {
                 UI.printMessage(e.getMessage());
             }
         } catch (InvalidStringException e) {
-            logger.log(Level.SEVERE, "Exception thrown.", e);
+            logger.log(Level.SEVERE, CP_EXCEPTION_LOG_MESSAGE, e);
         }
     }
 
@@ -232,8 +236,8 @@ public class CommandParser {
                 productQuantity = parseInt(components[INDEX_3]);
                 productPrice = parseDouble(components[INDEX_5]);
 
-                assert productQuantity >= 0 : "productQuantity is a negative number.";
-                assert productPrice > 0 : "productPrice is not a positive number.";
+                assert productQuantity >= 0 : CP_NEGATIVE_QUANTITY_MESSAGE;
+                assert productPrice > 0 : CP_NEGATIVE_PRICE_MESSAGE;
             } catch (NumberParsingFailedException e) {
                 throw new InvalidCommandException(CP_INVALID_NUMERAL_MESSAGE);
             }
@@ -303,8 +307,8 @@ public class CommandParser {
                 productNewQuantity = parseInt(components[INDEX_5]);
                 productNewPrice = parseDouble(components[INDEX_7]);
 
-                assert productNewQuantity >= 0 : "productNewQuantity is a negative number.";
-                assert productNewPrice > 0 : "productNewPrice is not a positive number.";
+                assert productNewQuantity >= 0 : CP_NEGATIVE_QUANTITY_MESSAGE;
+                assert productNewPrice > 0 : CP_NEGATIVE_PRICE_MESSAGE;
             } catch (NumberParsingFailedException e) {
                 throw new InvalidCommandException(CP_INVALID_NUMERAL_MESSAGE);
             }
@@ -348,7 +352,7 @@ public class CommandParser {
             try {
                 quantitySold = parseInt(components[INDEX_3]);
 
-                assert quantitySold >= 0 : "quantitySold is a negative number.";
+                assert quantitySold >= 0 : CP_NEGATIVE_QUANTITY_MESSAGE;
             } catch (NumberParsingFailedException e) {
                 throw new InvalidCommandException(CP_INVALID_NUMERAL_MESSAGE_2);
             }


### PR DESCRIPTION
Add enumeration to fix invalid businessType bug

There is a bug where businessType is not limited to RETAIL or FNB.
The code allows any String to work as a businessType.

This may lead to unpredictable behaviour in the code, as the code
does not expect the businessType to be anything else except FNB and
RETAIL.

Let's,
* Create a enumeration for businessType, so that only RETAIL and
FNB are allowed.
* Modify the businessType input code to combat against incorrect
inputs.
* Convert any remaining Strings created to constants.